### PR TITLE
FirebaseAuthでログイン時にFirestoreにユーザー用のドキュメントが作成されるようにしてください #13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "firebase_react_sample_app",
       "version": "0.0.0",
       "dependencies": {
-        "firebase": "^10.3.1",
+        "firebase": "^10.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0"
@@ -483,9 +483,9 @@
       "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw=="
     },
     "node_modules/@firebase/app": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.18.tgz",
-      "integrity": "sha512-SIJi3B/LzNezaEgbFCFIem12+51khkA3iewYljPQPUArWGSAr1cO9NK8TvtJWax5GMKSmQbJPqgi6a+gxHrWGQ==",
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.19.tgz",
+      "integrity": "sha512-t/SHyZ3xWkR77ZU9VMoobDNFLdDKQ5xqoCAn4o16gTsA1C8sJ6ZOMZ02neMOPxNHuQXVE4tA8ukilnDbnK7uJA==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
@@ -535,11 +535,11 @@
       "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ=="
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.18.tgz",
-      "integrity": "sha512-zUbAAZHhwmMUyaNFiFr+1Z/sfcxSQBFrRhpjzzpQMTfiV2C/+P0mC3BQA0HsysdGSYOlwrCs5rEGOyarhRU9Kw==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.19.tgz",
+      "integrity": "sha512-QkJDqYqjhvs4fTMcRVXQkP9hbo5yfoJXDWkhU4VA5Vzs8Qsp76VPzYbqx5SD5OmBy+bz/Ot1UV8qySPGI4aKuw==",
       "dependencies": {
-        "@firebase/app": "0.9.18",
+        "@firebase/app": "0.9.19",
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.3",
@@ -647,15 +647,15 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.1.3.tgz",
-      "integrity": "sha512-3kw/oZrLAIHuSDTAlKguZ1e0hAgWgiBl4QQm2mIPBvBAs++iEkuv9DH2tr6rbYpT6dWtdn6jj0RN0XeqOouJRg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.2.0.tgz",
+      "integrity": "sha512-iKZqIdOBJpJUcwY5airLX0W04TLrQSJuActOP1HG5WoIY5oyGTQE4Ml7hl5GW7mBqFieT4ojtUuDXj6MLrn1lA==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.3",
-        "@firebase/webchannel-wrapper": "0.10.2",
-        "@grpc/grpc-js": "~1.8.17",
+        "@firebase/webchannel-wrapper": "0.10.3",
+        "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
         "node-fetch": "2.6.7",
         "tslib": "^2.1.0"
@@ -668,12 +668,12 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.17.tgz",
-      "integrity": "sha512-Qh3tbE4vkn9XvyWnRaJM/v4vhCZ+btk2RZcq037o6oECHohaCFortevd/SKA4vA5yOx0/DwARIEv6XwgHkVucg==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.18.tgz",
+      "integrity": "sha512-hkqv4mb1oScKbEtzfcK8Go8c0VpDWmbAvbD6B6XnphLqi27pkXgo9Rp+aSKlD7cBL29VMEekP5bEm9lSVfZpNw==",
       "dependencies": {
         "@firebase/component": "0.6.4",
-        "@firebase/firestore": "4.1.3",
+        "@firebase/firestore": "4.2.0",
         "@firebase/firestore-types": "3.0.0",
         "@firebase/util": "1.9.3",
         "tslib": "^2.1.0"
@@ -937,16 +937,16 @@
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.2.tgz",
-      "integrity": "sha512-xDxhD9++451HuCv3xKBEdSYaArX9NcokODXZYH/MxGw1XFFOz7OKkTRItZ5wf6npBN/inwp8dUZCP7SpAg46yQ=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.3.tgz",
+      "integrity": "sha512-+ZplYUN3HOpgCfgInqgdDAbkGGVzES1cs32JJpeqoh87SkRobGXElJx+1GZSaDqzFL+bYiX18qEcBK76mYs8uA=="
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.21",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.21.tgz",
-      "integrity": "sha512-KeyQeZpxeEBSqFVTi3q2K7PiPXmgBfECc4updA1ejCLjYmoAlvvM3ZMp5ztTDUCUQmoY3CpDxvchjO1+rFkoHg==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.5.tgz",
+      "integrity": "sha512-iouYNlPxRAwZ2XboDT+OfRKHuaKHiqjB5VFYZ0NFrHkbEF+AV3muIUY9olQsp8uxU4VvRCMiRk9ftzFDGb61aw==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       },
       "engines": {
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.9.tgz",
-      "integrity": "sha512-YJsOehVXzgurc+lLAxYnlSMc1p/Gu6VAvnfx0ATi2nzvr0YZcjhmZDeY8SeAKv1M7zE3aEJH0Xo9mK1iZ8GYoQ==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -2651,23 +2651,23 @@
       }
     },
     "node_modules/firebase": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.3.1.tgz",
-      "integrity": "sha512-lUk1X0SQocShyIwz5x9mj829Yn1y4Y9KWriGLZ0/Pbwqt4ZxElx8rI1p/YAi4MZTtT1qi0wazo7dAlmuF6J0Aw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.4.0.tgz",
+      "integrity": "sha512-3Z8WsNwA7kbcKGZ+nrTZ/ES518pk0K440ZJYD8nUNKN5hV6ll+unhUw30t1msedN6yIFjhsC/9OwT4Z0ohwO2w==",
       "dependencies": {
         "@firebase/analytics": "0.10.0",
         "@firebase/analytics-compat": "0.2.6",
-        "@firebase/app": "0.9.18",
+        "@firebase/app": "0.9.19",
         "@firebase/app-check": "0.8.0",
         "@firebase/app-check-compat": "0.3.7",
-        "@firebase/app-compat": "0.2.18",
+        "@firebase/app-compat": "0.2.19",
         "@firebase/app-types": "0.9.0",
         "@firebase/auth": "1.3.0",
         "@firebase/auth-compat": "0.4.6",
         "@firebase/database": "1.0.1",
         "@firebase/database-compat": "1.0.1",
-        "@firebase/firestore": "4.1.3",
-        "@firebase/firestore-compat": "0.3.17",
+        "@firebase/firestore": "4.2.0",
+        "@firebase/firestore-compat": "0.3.18",
         "@firebase/functions": "0.10.0",
         "@firebase/functions-compat": "0.3.5",
         "@firebase/installations": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write \"**/*.+(js|json|yml|ts|tsx|less|sass)\""
   },
   "dependencies": {
-    "firebase": "^10.3.1",
+    "firebase": "^10.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0"

--- a/src/FirebaseConfig.ts
+++ b/src/FirebaseConfig.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from "firebase/app"
 import { getFirestore } from "firebase/firestore"
 import { getAuth } from "firebase/auth"
+import { getStorage } from "firebase/storage"
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -11,7 +12,17 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
   databaseURL: import.meta.env.VITE_FIREBASE_DATABASE_URL
 }
-const app = initializeApp(firebaseConfig)
+const firebaseApp = initializeApp(firebaseConfig)
 
-export const db = getFirestore(app)
-export const auth = getAuth(app)
+export const fireStore = getFirestore(firebaseApp)
+export const fireAuth = getAuth(firebaseApp)
+const fireStoreData = getStorage(firebaseApp)
+const db = getFirestore()
+
+export const firebaseApps = {
+  firebaseApp,
+  fireStore,
+  fireAuth,
+  fireStoreData,
+  db
+}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { signInWithEmailAndPassword, onAuthStateChanged } from "firebase/auth"
-import { auth } from "../FirebaseConfig"
+import { fireAuth } from "../FirebaseConfig"
 import { Navigate, Link } from "react-router-dom"
 
 const Login = () => {
@@ -12,7 +12,7 @@ const Login = () => {
     e.preventDefault()
 
     try {
-      await signInWithEmailAndPassword(auth, loginEmail, loginPassword)
+      await signInWithEmailAndPassword(fireAuth, loginEmail, loginPassword)
     } catch (error) {
       alert("メールアドレスまたはパスワードが間違っています")
     }
@@ -22,7 +22,7 @@ const Login = () => {
    * Firebaseでログインしているかを判断する
    */
   useEffect(() => {
-    onAuthStateChanged(auth, (currentUser) => {
+    onAuthStateChanged(fireAuth, (currentUser) => {
       if (!currentUser) return
       setIsLogin(true)
     })

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useLayoutEffect } from "react"
 import { useNavigate, Navigate, Link } from "react-router-dom"
-import type { User } from "@firebase/auth"
 import { onAuthStateChanged, signOut } from "firebase/auth"
-import { fireAuth, firebaseApps } from "../FirebaseConfig"
+import type { User } from "@firebase/auth"
 import { collection, doc, setDoc, serverTimestamp, getDoc, DocumentData } from "firebase/firestore"
+import { fireAuth, firebaseApps } from "../FirebaseConfig"
 
 export type userType = {
   display_name: string
@@ -66,6 +66,7 @@ const MyPage = () => {
 
   return (
     <>
+      {/* TODO: 三項演算子のネストが見通しが悪いので回収する */}
       {!isLoading ? (
         <>
           {!isLogin ? (

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -66,7 +66,7 @@ const MyPage = () => {
 
   return (
     <>
-      {/* TODO: 三項演算子のネストが見通しが悪いので回収する */}
+      {/* TODO: 三項演算子のネストが見通しが悪いので改修する */}
       {!isLoading ? (
         <>
           {!isLogin ? (

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -3,21 +3,28 @@ import { useNavigate, Navigate, Link } from "react-router-dom"
 import type { User } from "@firebase/auth"
 import { onAuthStateChanged, signOut } from "firebase/auth"
 import { fireAuth, firebaseApps } from "../FirebaseConfig"
-import { collection, doc, setDoc, serverTimestamp } from "firebase/firestore"
+import { collection, doc, setDoc, serverTimestamp, getDoc, DocumentData } from "firebase/firestore"
+
+export type userType = {
+  display_name: string
+  created_at: Date
+}
 
 const MyPage = () => {
-  const [user, setUser] = useState<User>()
+  const [authUserData, setAuthUserData] = useState<User>()
+  const [userData, setUserData] = useState<DocumentData>()
   const [isLoading, setIsLoading] = useState(true)
   const [isLogin, setIsLogin] = useState<boolean>(false)
 
   /**
    * Firebaseでログインしているかを判断する
-   * ログインしている場合はuser情報をstateに格納する
+   * ログインしている場合はauthUser情報をstateに格納する
    */
   useEffect(() => {
     onAuthStateChanged(fireAuth, (currentUser) => {
       if (!currentUser) return
-      setUser(currentUser)
+      // TODO: currentUser.uid まで格納されていてセキュリティ的によろしくないので使用するものだけ格納する
+      setAuthUserData(currentUser)
       setIsLogin(true)
       setIsLoading(false)
     })
@@ -25,16 +32,26 @@ const MyPage = () => {
 
   /**
    *  Firestore にユーザー用のドキュメントが作られていなければ作成する
+   *  存在する場合はstateにuserデータを入れる
    */
   useLayoutEffect(() => {
     fireAuth.onAuthStateChanged(async (currentUser) => {
       if (!currentUser) return
       const usersDocRef = collection(firebaseApps.db, "users")
-      await setDoc(doc(usersDocRef, currentUser.uid), {
-        // name: currentUser.uid,
-        display_name: "",
-        created_at: serverTimestamp()
-      })
+      const userDocumentRef = doc(firebaseApps.db, "users", currentUser.uid)
+
+      if (!userDocumentRef) {
+        await setDoc(doc(usersDocRef, currentUser.uid), {
+          // name: currentUser.uid,
+          display_name: "aa",
+          created_at: serverTimestamp()
+        })
+      } else {
+        getDoc(userDocumentRef).then((documentSnapshot) => {
+          if (!documentSnapshot) return
+          setUserData(documentSnapshot.data())
+        })
+      }
     })
   }, [])
 
@@ -43,6 +60,9 @@ const MyPage = () => {
     await signOut(fireAuth)
     navigate("/login/")
   }
+  const dateText = `${userData?.created_at.toDate().getFullYear()}年${
+    userData?.created_at.toDate().getMonth() + 1
+  }月${userData?.created_at.toDate().getDate()}日`
 
   return (
     <>
@@ -52,9 +72,15 @@ const MyPage = () => {
             <Navigate to={`/login/`} />
           ) : (
             <>
-              <h1>マイページ</h1>
-              <p>{user?.email}</p>
-              <button onClick={logout}>ログアウト</button>
+              <>
+                <h1>マイページ</h1>
+                <p>{authUserData?.email}</p>
+                <button onClick={logout}>ログアウト</button>
+              </>
+              <>
+                <p>{userData?.display_name}</p>
+                <p>{`作成日 ${dateText}`}</p>
+              </>
             </>
           )}
         </>

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import { Navigate, Link } from "react-router-dom"
 import { createUserWithEmailAndPassword, onAuthStateChanged } from "firebase/auth"
-import { auth } from "../FirebaseConfig"
+import { fireAuth } from "../FirebaseConfig"
 
 const Register = () => {
   const [registerEmail, setRegisterEmail] = useState("")
@@ -12,8 +12,9 @@ const Register = () => {
     e.preventDefault()
 
     try {
-      await createUserWithEmailAndPassword(auth, registerEmail, registerPassword)
+      await createUserWithEmailAndPassword(fireAuth, registerEmail, registerPassword)
     } catch (error) {
+      fireAuth
       alert("正しく入力してください")
     }
   }
@@ -22,7 +23,7 @@ const Register = () => {
    * Firebaseでログインしているかを判断する
    */
   useEffect(() => {
-    onAuthStateChanged(auth, (currentUser) => {
+    onAuthStateChanged(fireAuth, (currentUser) => {
       if (!currentUser) return
       setIsLogin(true)
     })


### PR DESCRIPTION
[Firebase Auth でログイン時に Firestore にユーザー用のドキュメントを作る方法](https://zenn.dev/rabee/articles/firebase-create-user-docment-in-firestore-at-login)

[Firebase入門 FireStore編(v9) ※編集中](https://zenn.dev/nash/articles/6e18bd94eca63e)

※ firebase Databaseのルールの設定を忘れずに
```
    match /users/{document} {
    	 allow read: if true;
       allow write: if true;
    
    }
    match /users/{document} {
    	allow read: if request.auth.uid == resource.data.userId;
    	allow write: if request.auth.uid == request.resource.data.userId;
    }
```